### PR TITLE
Uppercase first later in shared path reference

### DIFF
--- a/godot/Entities/Entities/Entity.gd
+++ b/godot/Entities/Entities/Entity.gd
@@ -2,7 +2,7 @@ class_name Entity
 extends Node2D
 
 const OUTLINE_SIZE := 3.0
-const OutlineMaterial := preload("res://shared/outline_material.tres")
+const OutlineMaterial := preload("res://Shared/outline_material.tres")
 
 export var deconstruct_filter: String
 

--- a/godot/SimulationDemo.tscn
+++ b/godot/SimulationDemo.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=12 format=2]
 
-[ext_resource path="res://Shared/tileset.tres" type="TileSet" id=1]
+[ext_resource path="res://Shared/Tileset.tres" type="TileSet" id=1]
 [ext_resource path="res://Entities/Player/Player.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Systems/Simulation.gd" type="Script" id=4]
 [ext_resource path="res://Entities/Entities/Natural/Tree/TreeEntity.tscn" type="PackedScene" id=5]


### PR DESCRIPTION
I know it's a bit early.

Feel free to close if it's not relevant anymore. 
There is a reference to `shared` directory but in should be `Shared` as all directories have the first letter uppercased.